### PR TITLE
Add software spreading coefficient

### DIFF
--- a/constants/meeting.js
+++ b/constants/meeting.js
@@ -113,6 +113,12 @@ const modificationTypes = {
   REMOVE: 'REMOVE'
 };
 
+/**
+ * Number of virtual meeting done with one software download.
+ * The software dowload damage is spread on those meetings.
+ */
+const softwareSpreading = 100;
+
 exports.hourToMinutes = hourToMinutes;
 exports.dayToHours = dayToHours;
 exports.minuteToSeconds = minuteToSeconds;
@@ -139,3 +145,5 @@ exports.possibleJourneys = possibleJourneys;
 exports.damageEndpoints = damageEndpoints;
 
 exports.modificationTypes = modificationTypes;
+
+exports.softwareSpreading = softwareSpreading;

--- a/database/meeting/software.js
+++ b/database/meeting/software.js
@@ -9,6 +9,8 @@ const software = {
     name: 'RENAVISIO',
     french: 'Renavisio',
     category: meetingComponents.SOFTWARE,
+    // True if software must be download (i.e. not reachable from browser)
+    isDownloaded: true,
     // in Mo
     fileSize: 18.8,
     // in Kbits/s
@@ -20,6 +22,7 @@ const software = {
     name: 'SKYPE',
     french: 'Skype',
     category: meetingComponents.SOFTWARE,
+    isDownloaded: true,
     fileSize: 65.8,
     // Indexed by number of participants
     // Source : https://support.skype.com/fr/faq/FA1417/quelle-est-la-quantite-de-bande-passante-necessaire-a-skype
@@ -49,6 +52,7 @@ const software = {
     name: 'JITSI',
     french: 'Jitsi',
     category: meetingComponents.SOFTWARE,
+    isDownloaded: false,
     /* Obtained summing size of all requests results when
     we load a launched Jitsi visioconference. Mean realized
     on visioconferences with 2, 3, 4 and 5 people.
@@ -68,6 +72,7 @@ const software = {
     name: 'HANGOUTS',
     french: 'Google Hangouts',
     category: meetingComponents.SOFTWARE,
+    isDownloaded: false,
     // Source : https://support.google.com/hangouts/answer/2944865?hl=fr
     bandwith: {
       inbound: {
@@ -90,6 +95,7 @@ const software = {
     name: 'ZOOM',
     french: 'Zoom',
     category: meetingComponents.SOFTWARE,
+    isDownloaded: true,
     // Source Zoom Mac archive (in Mo)
     fileSize: 25.5,
     // Source: https://support.zoom.us/hc/en-us/articles/201362023-System-requirements-for-Windows-macOS-and-Linux (in kbits/s)

--- a/model/classes/meeting/Software.js
+++ b/model/classes/meeting/Software.js
@@ -8,7 +8,8 @@ const {
   moToOctets,
   kbitToBits,
   minuteToSeconds,
-  bounds
+  bounds,
+  softwareSpreading
 } = require('../../../constants/meeting');
 const networkDatabase = require('../../../database/meeting/network');
 const softwareDatabase = require('../../../database/meeting/software');
@@ -32,11 +33,20 @@ class Software extends Component {
 
     super({ french: json.french, category: json.category });
     this.name = json.name;
+    this._isDownloaded = json.isDownloaded;
     this._fileSize = json.fileSize;
     this._bandwith = json.bandwith;
   }
 
   // Getter
+
+  /**
+   * Getter for software isDoawloaded attribute.
+   * True if the software must be downloaded (i.e. not reachable from browser).
+   */
+  get isDownloaded () {
+    return this._isDownloaded;
+  }
 
   /**
    * Getter for software file size.
@@ -67,6 +77,13 @@ class Software extends Component {
   }
 
   // Setters
+
+  /**
+   * Setter for software isDoawloaded attribut.
+   */
+  set isDownloaded (isDownloaded) {
+    this._isDownloaded = isDownloaded;
+  }
 
   /**
    * Setter for software file size.
@@ -222,9 +239,17 @@ class Software extends Component {
     // We get the file size in bits
     const fileSize = this.fileSizeMoToBits();
 
+    /* If the software must be downloaded, get the number of
+       virtual meetings done before a new download.
+       Else, if the software is reachable from browser,
+       the download damage is spread on one use.
+    */
+    const damageSpreading = this.isDownloaded ? softwareSpreading : 1;
+    console.log("softwareSpreading", damageSpreading)
+
     // We compute the total damage for each damage shere (in damageUnit)
     Object.keys(embodiedDamage).forEach((categoryDamage) => {
-      embodiedDamage[categoryDamage] = networkEnergeticIntensity[categoryDamage] * fileSize * instancesNumber;
+      embodiedDamage[categoryDamage] = (networkEnergeticIntensity[categoryDamage] * fileSize * instancesNumber) / damageSpreading;
     });
 
     // Return the computed embodied damage


### PR DESCRIPTION
fix #25 

J'ai : 
* créé la constante `softwareSpreading` dans le fichier dédié (didier 🐶) ;
* ajouté à chaque logiciel dans la bdd un booléen `isDownloaded` pour discriminer les logiciels accessibles dans le navigateur de ceux qu'il faut télécharger ;
* appliqué le coefficient `softwareSpreading` dans le calcul de l'impact "embodied" du logiciel, en fonction de la valeur de `isDownloaded`.